### PR TITLE
Promote sqlite to recommendation, suggest reverse proxies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,9 @@ Depends: adduser,
          ${misc:Depends},
          ${shlibs:Depends},
 Recommends: vaultwarden-doc (= ${source:Version}),
+            sqlite3,
 Suggests: sqlite3 | postgresql | default-mysql-server | virtual-mysql-server,
+          nginx | caddy,
 Description: Unofficial Bitwarden compatible server written in Rust
  Alternative implementation of the Bitwarden server API written in Rust and
  compatible with upstream Bitwarden clients*, perfect for self-hosted


### PR DESCRIPTION
The server is going to be virtually useless without a DB, so they should be recommended more strongly. The docs discourage exposing the Rocket backend directly to the Internet, so suggesting reverse proxy packages is probably useful.