### PR TITLE
move real configuration file to /etc/vaultwarden/vaultwarden.env

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vaultwarden (1.35.4-5) UNRELEASED; urgency=medium
+
+  * move real configuration file to /etc/vaultwarden/vaultwarden.env, set permissions on config and data directories
+
+ -- dionysius <dragon.dionysius@gmail.com>  Thu, 09 Apr 2026 04:45:06 +0200
+
 vaultwarden (1.35.4-4) unstable; urgency=medium
 
   * use upstream-vcs-tag import so upstream git history doesn't get lost

--- a/debian/patches/0001_config.patch
+++ b/debian/patches/0001_config.patch
@@ -1,0 +1,26 @@
+diff --git a/.env.template b/.env.template
+index 03990820..11ef17ee 100644
+--- a/.env.template
++++ b/.env.template
+@@ -5,10 +5,8 @@
+ ## Be aware that most of these settings will be overridden if they were changed
+ ## in the admin interface. Those overrides are stored within DATA_FOLDER/config.json .
+ ##
+-## By default, Vaultwarden expects for this file to be named ".env" and located
+-## in the current working directory. If this is not the case, the environment
+-## variable ENV_FILE can be set to the location of this file prior to starting
+-## Vaultwarden.
++## This file is referenced via the ENV_FILE variable in the vaultwarden systemd service
++## which instructs vaultwarden to load it as a configuration file.
+ 
+ ####################
+ ### Data folders ###
+@@ -42,7 +40,7 @@
+ # RELOAD_TEMPLATES=false
+ 
+ ## Web vault settings
+-# WEB_VAULT_FOLDER=web-vault/
++WEB_VAULT_FOLDER=/usr/share/vaultwarden-web-vault/
+ # WEB_VAULT_ENABLED=true
+ 
+ #########################

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+0001_config.patch

--- a/debian/rules
+++ b/debian/rules
@@ -65,9 +65,8 @@ override_dh_auto_install:
 	cargo install $(cargoinstallargs) --locked --path . --root debian/tmp
 	mv debian/tmp/bin debian/tmp/usr
 
-# use upstream env template as defaults with some maintainer defaults
-	mv .env.template debian/vaultwarden.default
-	sed -i 's|^# WEB_VAULT_FOLDER=.*|WEB_VAULT_FOLDER=/usr/share/vaultwarden-web-vault/|g' debian/vaultwarden.default
+# use upstream env template as config file with some maintainer defaults (see patch)
+	mv .env.template debian/tmp/vaultwarden.env
 
 	dh_auto_install -- --no-source
 

--- a/debian/vaultwarden.NEWS
+++ b/debian/vaultwarden.NEWS
@@ -1,0 +1,12 @@
+vaultwarden (1.35.4-5) unstable; urgency=medium
+
+  * The configuration file has moved from /etc/default/vaultwarden to
+    /etc/vaultwarden/vaultwarden.env. Any local modifications are automatically
+    preserved by the package upgrade.
+  * Permissions on /etc/vaultwarden, /var/lib/vaultwarden and
+    /var/lib/vaultwarden/data have been tightened to 750 with vaultwarden
+    user/group. If you have customised these permissions, register your
+    changes with dpkg-statoverride(8) to ensure they survive future
+    upgrades.
+
+ -- dionysius <dragon.dionysius@gmail.com>  Wed, 08 Apr 2026 20:27:56 +0200

--- a/debian/vaultwarden.default
+++ b/debian/vaultwarden.default
@@ -1,0 +1,6 @@
+# Default settings for vaultwarden. This file is sourced by the vaultwarden systemd service.
+# The vaultwarden configuration file has moved to /etc/vaultwarden/vaultwarden.env.
+# Some crates allow customization via environment variables.
+
+# Tokio by default spawns one thread for each CPU core (https://docs.rs/tokio/latest/tokio/#cpu-bound-tasks-and-blocking-code)
+#TOKIO_WORKER_THREADS=

--- a/debian/vaultwarden.dirs
+++ b/debian/vaultwarden.dirs
@@ -1,3 +1,2 @@
-/etc/vaultwarden
 /var/lib/vaultwarden
 /var/lib/vaultwarden/data

--- a/debian/vaultwarden.install
+++ b/debian/vaultwarden.install
@@ -1,1 +1,2 @@
 usr/bin/vaultwarden
+vaultwarden.env etc/vaultwarden

--- a/debian/vaultwarden.links
+++ b/debian/vaultwarden.links
@@ -1,1 +1,0 @@
-etc/default/vaultwarden etc/vaultwarden/vaultwarden.env

--- a/debian/vaultwarden.postinst
+++ b/debian/vaultwarden.postinst
@@ -3,7 +3,35 @@ set -e
 
 if [ "$1" = "configure" ]; then
   adduser --system --group --quiet --no-create-home --home /var/lib/vaultwarden vaultwarden >/dev/null || true
-  chown vaultwarden:vaultwarden /var/lib/vaultwarden /var/lib/vaultwarden/data
+
+  # TODO: consider using systemd *Directory* options
+  # TODO2: If switched to systemd options, update NEWS
+  for i in /etc/vaultwarden; do
+   if ! dpkg-statoverride --list $i >/dev/null 2>&1; then
+     dpkg-statoverride --update --add root vaultwarden 750 $i
+   fi
+  done
+  for i in /var/lib/vaultwarden /var/lib/vaultwarden/data; do
+    if ! dpkg-statoverride --list $i >/dev/null 2>&1; then
+      dpkg-statoverride --update --add vaultwarden vaultwarden 750 $i
+    fi
+  done
 fi
+
+# # Finalize upgrade from < 1.35.4-5~ (delayed variant)
+# if [ "$1" = "configure" ] && dpkg --compare-versions "$2" lt "1.35.4-5~"; then
+#   if [ -f /etc/default/vaultwarden.dpkg-bak ]; then
+#     mv -f /etc/default/vaultwarden.dpkg-bak /etc/vaultwarden/vaultwarden.env
+#     echo "vaultwarden: Preserving user changes from /etc/default/vaultwarden to /etc/vaultwarden/vaultwarden.env" >&2
+#   fi
+# fi
+
+# # Abort upgrade from < 1.35.4-5~ (delayed variant)
+# if [ "$1" = "abort-upgrade" ] && dpkg --compare-versions "$2" lt "1.35.4-5~"; then
+#   if [ -f /etc/default/vaultwarden.dpkg-bak ]; then
+#     mv -f /etc/default/vaultwarden.dpkg-bak /etc/default/vaultwarden
+#     echo "vaultwarden: Reinstalling /etc/default/vaultwarden that was moved away" >&2
+#   fi
+# fi
 
 #DEBHELPER#

--- a/debian/vaultwarden.postrm
+++ b/debian/vaultwarden.postrm
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "purge" ]; then
+  for path in /var/lib/vaultwarden /var/lib/vaultwarden/data /etc/vaultwarden; do
+    if dpkg-statoverride --list "$path" >/dev/null 2>&1; then
+      dpkg-statoverride --remove "$path"
+    fi
+  done
+fi
+
+# # Finalize downgrade to < 1.35.4-5~
+# if [ "$1" = "configure" ] && dpkg --compare-versions "$2" lt "1.35.4-5~"; then
+#   if [ -f /etc/vaultwarden/vaultwarden.env.dpkg-bak ]; then
+#     mv -f /etc/vaultwarden/vaultwarden.env.dpkg-bak /etc/default/vaultwarden
+#     echo "vaultwarden: Preserving user changes from /etc/vaultwarden/vaultwarden.env to /etc/default/vaultwarden" >&2
+#   fi
+# fi
+
+# # Abort downgrade to < 1.35.4-5~
+# if [ "$1" = "abort-upgrade" ] && dpkg --compare-versions "$2" lt "1.35.4-5~"; then
+#   if [ -f /etc/vaultwarden/vaultwarden.env.dpkg-bak ]; then
+#     mv -f /etc/vaultwarden/vaultwarden.env.dpkg-bak /etc/vaultwarden/vaultwarden.env
+#     echo "vaultwarden: Reinstalling /etc/vaultwarden/vaultwarden.env that was moved away" >&2
+#   fi
+# fi
+
+#DEBHELPER#

--- a/debian/vaultwarden.preinst
+++ b/debian/vaultwarden.preinst
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+# Upgrade from < 1.35.4-5~: move configuration forth (direct)
+if [ "$1" = "upgrade" ] && dpkg --compare-versions "$2" lt "1.35.4-5~"; then
+  if [ -f /etc/default/vaultwarden ]; then
+    mv -f /etc/default/vaultwarden /etc/vaultwarden/vaultwarden.env
+  fi
+fi
+
+# # Upgrade from < 1.35.4-5~: move configuration forth (delayed)
+# # Manually needed since dpkg-maintscript-helper would wrongfully compare the new
+# # defaults with the whole configuration file since the move happens after unpack.
+# if [ "$1" = "upgrade" ] && dpkg --compare-versions "$2" lt "1.35.4-5~"; then
+#   if [ -f /etc/default/vaultwarden ]; then
+#     mv -f /etc/default/vaultwarden /etc/default/vaultwarden.dpkg-bak
+#   fi
+# fi
+
+#DEBHELPER#

--- a/debian/vaultwarden.prerm
+++ b/debian/vaultwarden.prerm
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+# Downgrade to < 1.35.4-5~: move configuration back (direct)
+if [ "$1" = "upgrade" ] && dpkg --compare-versions "$2" lt "1.35.4-5~"; then
+  if [ -f /etc/vaultwarden/vaultwarden.env ]; then
+    mv -f /etc/vaultwarden/vaultwarden.env /etc/default/vaultwarden
+  fi
+fi
+
+# # Downgrade to < 1.35.4-5~: move configuration back (delayed)
+# # Manually needed since unpack would overwrite /etc/vaultwarden/vaultwarden.env
+# # with the old symlink.
+# if [ "$1" = "upgrade" ] && dpkg --compare-versions "$2" lt "1.35.4-5~"; then
+#   if [ -f /etc/vaultwarden/vaultwarden.env ]; then
+#     mv -f /etc/vaultwarden/vaultwarden.env /etc/vaultwarden/vaultwarden.env.dpkg-bak
+#   fi
+# fi
+
+#DEBHELPER#

--- a/debian/vaultwarden.service
+++ b/debian/vaultwarden.service
@@ -26,8 +26,10 @@ After=network.target
 # The user/group vaultwarden is run under. the working directory (see below) should allow write and read access to this user/group
 User=vaultwarden
 Group=vaultwarden
+# Load environment variables from the default file
+EnvironmentFile=-%E/default/vaultwarden
 # The location of the env file for configuration
-EnvironmentFile=/etc/default/vaultwarden
+Environment=ENV_FILE=%E/vaultwarden/vaultwarden.env
 # The location of the compiled binary
 ExecStart=/usr/bin/vaultwarden
 # Set reasonable connection and process limits


### PR DESCRIPTION
This is the first part of a series of changes proposed in #27. co-author @ISSOtm 

- The defined configuration file is now /etc/vaultwarden/vaultwarden.env.
- The default file can be used to still define env variables for the vaultwarden service, currently holds notice for this migration
- Migrations for upgrade and downgrade, existing changes to the previous file must be taken over

For this PR out-of-scope:
- ucf
