### PR TITLE
link against system sqlite3 instead of bundled

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,7 +25,7 @@ endif
 ifneq (,$(filter features=%,$(DEB_BUILD_OPTIONS)))
 	cargoinstallargs += --features $(patsubst features=%,%,$(filter features=%,$(DEB_BUILD_OPTIONS)))
 else
-	cargoinstallargs += --features sqlite,mysql,postgresql,s3
+	cargoinstallargs += --features sqlite_system,mysql,postgresql,s3
 endif
 
 # convert GNU triplet to Rust target triple


### PR DESCRIPTION
Thanks to @ISSOtm [contribution](https://github.com/dani-garcia/vaultwarden/pull/7057) vaultwarden has now an option to use the systems sqlite library.

dpkg will automatically add the library to the dependencies of the vaultwarden package: (on my older system)
> Depends: ..., libsqlite3-0 (>= 3.20.0), ...

@ISSOtm Do you know by accident if this has any implications on existing databases? I assume I may need to create a backup during upgrade just to be safe?