### PR TITLE
Fix File Send

### DIFF
--- a/debian/vaultwarden.service
+++ b/debian/vaultwarden.service
@@ -83,7 +83,7 @@ ProtectProc=noaccess
 ProcSubset=pid
 
 # Namespace isolation
-PrivateTmp=disconnected
+PrivateTmp=true
 PrivateDevices=true
 PrivateIPC=true
 PrivateBPF=true


### PR DESCRIPTION
With the current systemd parameter
`PrivateTmp=disconnected`

I'm unable to save File Send.

Vaultwarden WebUI reports:
> Error
> An error has occurred.
> An unexpected error has occurred."

And there are such records in logs
`journalctl -u vaultwarden --no-pager`

> Jun 04 09:50:01 debian vaultwarden[1819]: [2026-06-04 09:50:01.089][request][INFO] POST /api/sends/file/v2
> Jun 04 09:50:01 debian vaultwarden[1819]: [2026-06-04 09:50:01.091][response][INFO] (post_send_file_v2) POST /api/sends/file/v2 => 200 OK
> Jun 04 09:50:01 debian vaultwarden[1819]: [2026-06-04 09:50:01.097][request][INFO] POST /api/sends/995308eb-ecec-4330-a97f-674180281117/file/55adef5b09c8dee774ae595c22f7d1f5a4ab80b5102918676715cfcf2cfb8ce8
> Jun 04 09:50:01 debian vaultwarden[1819]: [2026-06-04 09:50:01.098][vaultwarden::api::core::sends::_][WARN] Data guard `Form < UploadDataV2 < '_ > >` failed: Errors([Error { name: Some("data"), value: None, kind: Io(Custom { kind: ReadOnlyFilesystem, error: PathError { path: "/var/tmp/.tmpXppavx", err: Os { code: 30, kind: ReadOnlyFilesystem, message: "Read-only file system" } } }), entity: Form }]).
> Jun 04 09:50:01 debian vaultwarden[1819]: [2026-06-04 09:50:01.098][response][INFO] (post_send_file_v2_data) POST /api/sends/<send_id>/file/<file_id> multipart/form-data => 400 Bad Request
> Jun 04 09:50:01 debian vaultwarden[1819]: [2026-06-04 09:50:01.103][request][INFO] DELETE /api/sends/995308eb-ecec-4330-a97f-674180281117
> Jun 04 09:50:01 debian vaultwarden[1819]: [2026-06-04 09:50:01.104][response][INFO] (delete_send) DELETE /api/sends/<send_id> => 200 OK

I was able to fix this with either of these options:
1. Changing `TMP_FOLDER` from `/var/tmp` to `data/tmp` in `/etc/vaultwarden/vaultwarden.env`
2. Using systemd override `systemctl edit vaultwarden.service`

```
[Service]
PrivateTmp=true
```

To me both options look fine, but since we have debian/patches/0001_config.patch that sets TMP_FOLDER, I decided to go with systemd parameter that is also [used in alternative Debian packaging](https://github.com/greizgh/vaultwarden-debian/blob/2e2cdbfc6980561e8c2976d013b82e6003ea409e/debian/vaultwarden.service#L9) .