### PR TITLE
Add systemd file templating

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: web
 Priority: optional
 Build-Depends: debhelper-compat (= 13),
                dh-sequence-installsysusers,
+               fypp:native,
                help2man <!cross>,
                libmariadb-dev-compat | libmysqlclient-dev,
                libpq-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -54,6 +54,14 @@ export ZSTD_SYS_USE_PKG_CONFIG = 1
 # set version env so compilation can include it
 export VW_VERSION = $(DEB_VERSION_UPSTREAM)
 
+# Detect systemd major version for service file templating.
+# On bookworm systemd.pc ships with the systemd package; on newer distros it moved to systemd-dev.
+# TODO: once bookworm is phased out, add systemd-dev to Build-Depends and drop the dpkg-query fallback.
+SYSTEMD_MAJOR := $(shell pkgconf --modversion systemd 2>/dev/null)
+ifeq ($(SYSTEMD_MAJOR),)
+SYSTEMD_MAJOR := $(shell dpkg-query -W -f='$${Version}' systemd 2>/dev/null | cut -d. -f1)
+endif
+
 %:
 	dh $@
 
@@ -80,3 +88,6 @@ ifeq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
 	ls -1 -d debian/tmp/man/vaultwarden-doc/* > "debian/vaultwarden-doc.manpages"
 endif
 	dh_installman
+
+execute_before_dh_installsystemd:
+	fypp -DSYSTEMD_MAJOR=$(SYSTEMD_MAJOR) debian/vaultwarden.service.fypp debian/vaultwarden.service

--- a/debian/rules
+++ b/debian/rules
@@ -59,7 +59,7 @@ export VW_VERSION = $(DEB_VERSION_UPSTREAM)
 # TODO: once bookworm is phased out, add systemd-dev to Build-Depends and drop the dpkg-query fallback.
 SYSTEMD_MAJOR := $(shell pkgconf --modversion systemd 2>/dev/null)
 ifeq ($(SYSTEMD_MAJOR),)
-SYSTEMD_MAJOR := $(shell dpkg-query -W -f='$${Version}' systemd 2>/dev/null | cut -d. -f1)
+SYSTEMD_MAJOR := $(shell dpkg-query -W -f='$${Version}' libsystemd0 2>/dev/null | cut -d. -f1)
 endif
 
 %:

--- a/debian/vaultwarden.service.fypp
+++ b/debian/vaultwarden.service.fypp
@@ -36,8 +36,13 @@ WorkingDirectory=/var/lib/vaultwarden
 ## Permissions and directories
 User=vaultwarden
 Group=vaultwarden
+#:if SYSTEMD_MAJOR >= 257
 # Read-only configuration directory (read-only mount, permissions managed by tmpfiles, warns if mode differs).
 ConfigurationDirectory=vaultwarden::ro
+#:else
+# Configuration directory (permissions managed by tmpfiles, warns if mode differs).
+ConfigurationDirectory=vaultwarden
+#:endif
 ConfigurationDirectoryMode=0500
 # Writable directories (read-write for the service, read-only for the group, reapplies permissions recursively if different).
 StateDirectory=vaultwarden
@@ -83,21 +88,33 @@ ProtectProc=noaccess
 ProcSubset=pid
 
 # Namespace isolation
+#:if SYSTEMD_MAJOR >= 257
 PrivateTmp=disconnected
+#:else
+PrivateTmp=true
+#:endif
 PrivateDevices=true
 PrivateIPC=true
+#:if SYSTEMD_MAJOR >= 258
 PrivateBPF=true
+#:endif
 
 # Kernel and system protection
 ProtectClock=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectKernelLogs=true
+#:if SYSTEMD_MAJOR >= 257
 ProtectControlGroups=strict
+#:else
+ProtectControlGroups=true
+#:endif
 
 # Execution restrictions
 MemoryDenyWriteExecute=true
+#:if SYSTEMD_MAJOR >= 255
 SetLoginEnvironment=false
+#:endif
 
 # System call and network filtering
 SystemCallFilter=@system-service


### PR DESCRIPTION
Supersedes: #37
Fixes: #38

It was bound to happen one day that a directive is not understood in older systemd versions and its interpretations not yielding the desired effect. By introducing a small template we can also target warnings and be more specific for each supported version.